### PR TITLE
Update setup.py to fix haystack installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="marketing@assemblyai.com",
     packages=find_packages(),
     install_requires=[
-        "haystack-ai>=0.137.0",
+        "haystack-ai",
         "assemblyai>=0.18.0",
     ],
     extras_require={


### PR DESCRIPTION
Haystack removed some of their latest releases, there is no 0.137.0 version anymore. By their advice, removed the version limitation on the requirements.